### PR TITLE
fix the problem that gc value is overwritten with nil if LastGcInfo is null.

### DIFF
--- a/lib/hadoop_metrics/api.rb
+++ b/lib/hadoop_metrics/api.rb
@@ -32,20 +32,24 @@ module HadoopMetrics
 
     def gc
       disable_snake_case {
-        result = query_jmx('java.lang:type=GarbageCollector,name=*').map { |jmx_gc_info|
-          return nil if jmx_gc_info['LastGcInfo'].nil?
+        
+        result = []
+        query_jmx('java.lang:type=GarbageCollector,name=*').each { |jmx_gc_info|
+          unless jmx_gc_info['LastGcInfo'].nil?
 
-          gc_info = {'type' => GCNameMap[jmx_gc_info['Name']]}
-          gc_info['estimated_time'] = jmx_gc_info['CollectionTime']
-          gc_info['count'] = jmx_gc_info['CollectionCount']
+            gc_info = {'type' => GCNameMap[jmx_gc_info['Name']]}
+            gc_info['estimated_time'] = jmx_gc_info['CollectionTime']
+            gc_info['count'] = jmx_gc_info['CollectionCount']
 
-          last_gc_info = jmx_gc_info['LastGcInfo']
-          gc_info['last_start'] = last_gc_info['startTime']
-          gc_info['last_duration'] = last_gc_info['duration']
-          gc_info['after_gc'] = calc_memory_usage(last_gc_info)
+            last_gc_info = jmx_gc_info['LastGcInfo']
+            gc_info['last_start'] = last_gc_info['startTime']
+            gc_info['last_duration'] = last_gc_info['duration']
+            gc_info['after_gc'] = calc_memory_usage(last_gc_info)
 
-          gc_info
+            result << gc_info
+          end
         }
+        result
       }
     end
 


### PR DESCRIPTION
Hi

If LastGcInfo is null, gc value is overwritten with nil. so hadoop_metrics returns always nil.

example code

```
require 'hadoop_metrics/name_node'

nn = HadoopMetrics::NameNode.new('localhost', 50070)
puts nn.gc # nil
```

If there is the following JMX JSON value, ParNew is overwritten with nil because LastGcInfo of ConcurrentMarkSweep is null

URL:http://.../jmx?qry=java.lang:type=GarbageCollector,name=*

```
{
  "beans" : [ {
    "name" : "java.lang:type=GarbageCollector,name=ParNew",
    "modelerType" : "sun.management.GarbageCollectorImpl",
    "LastGcInfo" : {
      "GcThreadCount" : 11,
      "duration" : 10,
      "endTime" : 2728959786,
      "id" : 9411,
      "memoryUsageAfterGc" : [ {
        "key" : "CMS Perm Gen",
        "value" : {
          "committed" : 44564480,
          "init" : 21757952,
          "max" : 85983232,
          "used" : 44474176
        }
      }, {
        "key" : "Par Eden Space",
        "value" : {
          "committed" : 167772160,
          "init" : 167772160,
          "max" : 167772160,
          "used" : 0
        }
      }, {
        "key" : "Code Cache",
        "value" : {
          "committed" : 10813440,
          "init" : 2555904,
          "max" : 50331648,
          "used" : 10616128
        }
      }, {
        "key" : "Par Survivor Space",
        "value" : {
          "committed" : 20971520,
          "init" : 20971520,
          "max" : 20971520,
          "used" : 5174184
        }
      }, {
        "key" : "CMS Old Gen",
        "value" : {
          "committed" : 8380219392,
          "init" : 8380219392,
          "max" : 8380219392,
          "used" : 3845674656
        }
      } ],
      "memoryUsageBeforeGc" : [ {
        "key" : "CMS Perm Gen",
        "value" : {
          "committed" : 44564480,
          "init" : 21757952,
          "max" : 85983232,
          "used" : 44474176
        }
      }, {
        "key" : "Par Eden Space",
        "value" : {
          "committed" : 167772160,
          "init" : 167772160,
          "max" : 167772160,
          "used" : 167772160
        }
      }, {
        "key" : "Code Cache",
        "value" : {
          "committed" : 10813440,
          "init" : 2555904,
          "max" : 50331648,
          "used" : 10616128
        }
      }, {
        "key" : "Par Survivor Space",
        "value" : {
          "committed" : 20971520,
          "init" : 20971520,
          "max" : 20971520,
          "used" : 4853536
        }
      }, {
        "key" : "CMS Old Gen",
        "value" : {
          "committed" : 8380219392,
          "init" : 8380219392,
          "max" : 8380219392,
          "used" : 3845674656
        }
      } ],
      "startTime" : 2728959776
    },
    "CollectionCount" : 9411,
    "CollectionTime" : 118743,
    "MemoryPoolNames" : [ "Par Eden Space", "Par Survivor Space" ],
    "Name" : "ParNew",
    "Valid" : true,
    "ObjectName" : "java.lang:type=GarbageCollector,name=ParNew"
  }, {
    "name" : "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep",
    "modelerType" : "sun.management.GarbageCollectorImpl",
    "LastGcInfo" : null,
    "CollectionCount" : 0,
    "CollectionTime" : 0,
    "MemoryPoolNames" : [ "Par Eden Space", "Par Survivor Space", "CMS Old Gen", "CMS Perm Gen" ],
    "Name" : "ConcurrentMarkSweep",
    "Valid" : true,
    "ObjectName" : "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep"
  } ]
}
```

In this case, ConcurrentMarkSweep is not executed. So, I think that it's rare case.
